### PR TITLE
Bug in hash creating

### DIFF
--- a/core/Experiment.py
+++ b/core/Experiment.py
@@ -154,13 +154,13 @@ class ExperimentClass:
     def name(self): return type(self).__name__
 
     def log_conditions(self, conditions, condition_tables=['Condition'], schema='experiment', hsh='cond_hash', priority=2):
-        fields, hash_dict = list(), dict()
+        fields_hash, hash_dict = list(), dict()
         for ctable in condition_tables:
             table = rgetattr(eval(schema), ctable)
-            fields += list(table().heading.names)
+            fields_hash += list(table().heading.names)
         for cond in conditions:
             insert_priority = priority
-            key = {sel_key: cond[sel_key] for sel_key in fields if sel_key != hsh and sel_key in cond}  # find all dependant fields and generate hash
+            key = {sel_key: cond[sel_key] for sel_key in fields_hash if sel_key != hsh and sel_key in cond}  # find all dependant fields and generate hash
             cond.update({hsh: make_hash(key)})
             hash_dict[cond[hsh]] = cond[hsh]
             for ctable in condition_tables:  # insert dependant condition tables

--- a/core/Experiment.py
+++ b/core/Experiment.py
@@ -154,13 +154,13 @@ class ExperimentClass:
     def name(self): return type(self).__name__
 
     def log_conditions(self, conditions, condition_tables=['Condition'], schema='experiment', hsh='cond_hash', priority=2):
-        fields_hash, hash_dict = list(), dict()
+        fields_key, hash_dict = list(), dict()
         for ctable in condition_tables:
             table = rgetattr(eval(schema), ctable)
-            fields_hash += list(table().heading.names)
+            fields_key += list(table().heading.names)
         for cond in conditions:
             insert_priority = priority
-            key = {sel_key: cond[sel_key] for sel_key in fields_hash if sel_key != hsh and sel_key in cond}  # find all dependant fields and generate hash
+            key = {sel_key: cond[sel_key] for sel_key in fields_key if sel_key != hsh and sel_key in cond}  # find all dependant fields and generate hash
             cond.update({hsh: make_hash(key)})
             hash_dict[cond[hsh]] = cond[hsh]
             for ctable in condition_tables:  # insert dependant condition tables


### PR DESCRIPTION
**fields** variable is declared on line 160 with all the arguments of the condition_tables
But then there is a for loop  at line 166 which loop for all the tables in order to insert dependant condition tables 
- at line 168 in order to find the fields for each table it assign to the **fields** variable the attributes for each schema so after the loop the fields variable has the values of the last ctable from the conditions table so  in the next iteration the fields has different values and accordingly the key at line 163

The solution i propose is to change the name of the first variable as fields_hash because it is used only for creating the key