### PR TITLE
Bug that make experiment to go from sleeping to ready instead of running

### DIFF
--- a/core/Experiment.py
+++ b/core/Experiment.py
@@ -82,7 +82,6 @@ class ExperimentClass:
         self.logger.ping(0)
         self.logger.closeDatasets()
         self.running = False
-        self.logger.update_setup_info({'status': 'stop'})
 
     def is_stopped(self):
         self.quit = self.quit or self.logger.setup_status in ['stop', 'exit']


### PR DESCRIPTION
At function stop from ExperimentClass that is called at all
Experiments  Exit the status is updating to 'stop'

This has been introduced at commit: https://github.com/ef-lab/PyMouse/commit/522bad30390e9d9502b7c315913134a0fad70f30#diff-e6bac521a131cd3e2d524dd824f9d9c63e735dc74f647c25d9e590b600549184 and I think that was mainly to avoid repeating the:

-   self.stim.exit()
-   self.beh.exit()
-   self.logger.ping(0)

and add

- self.logger.closeDatasets()
- self.running = False

update_setup_info({'status': 'stop'}) is only used at DummyPorts and at _touch_handler in RPPorts to exit manually from the session and then go to ready

The only confusing thing is the name of function stop at class ExperimentClass which implies that the experiment should be stopped and therefore the status also should be changed to stop