### PR TITLE
Change background color in setup function of RPScreen

### DIFF
--- a/Stimuli/RPScreen.py
+++ b/Stimuli/RPScreen.py
@@ -15,7 +15,9 @@ class RPScreen(Stimulus):
         self.unshow()
         pygame.mouse.set_visible(0)
         pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
-
+        self.screen.fill(self.color)
+        self.flip()
+        
     def ready_stim(self):
         self.unshow([64, 64, 64])
 


### PR DESCRIPTION
Make this change in order to have a color in pretrial state and indicate the beginning of the trial and the start of the session because in the case of the auditory and odor stimulus the mouse cannot know when the session/trial starts