### PR TITLE
Changes in MatchPort and Pandas

### DIFF
--- a/Experiments/MatchPort.py
+++ b/Experiments/MatchPort.py
@@ -122,6 +122,9 @@ class Trial(Experiment):
 
 
 class Abort(Experiment):
+    def entry(self):
+        self.stim.unshow()
+
     def run(self):
         self.beh.update_history()
         self.logger.log('Trial.Aborted')

--- a/Experiments/MatchPort.py
+++ b/Experiments/MatchPort.py
@@ -103,7 +103,7 @@ class Trial(Experiment):
             self.stim.ready_stim()
 
     def next(self):
-        if not self.resp_ready and self.response:          # did not wait
+        if not self.resp_ready and self.beh.interface.in_position()==(0,0,0):  # did not wait & 
             return 'Abort'
         elif self.response and not self.beh.is_correct():  # response to incorrect probe
             return 'Punish'
@@ -131,7 +131,6 @@ class Abort(Experiment):
 
 
 class Reward(Experiment):
-
     def entry(self):
         super().entry()
         self.stim.reward_stim()

--- a/Experiments/MatchPort.py
+++ b/Experiments/MatchPort.py
@@ -183,7 +183,7 @@ class InterTrial(Experiment):
             return 'Hydrate'
         elif self.beh.is_sleep_time() or self.beh.is_hydrated():
             return 'Offtime'
-        elif self.state_timer.elapsed_time() >= self.stim.curr_cond['intertrial_duration']:
+        elif self.state_timer.elapsed_time() >= self.stim.curr_cond['intertrial_duration'] and self.beh.is_off_proximity():
             return 'PreTrial'
         else:
             return 'InterTrial'

--- a/Experiments/MatchPort.py
+++ b/Experiments/MatchPort.py
@@ -71,6 +71,7 @@ class PreTrial(Experiment):
         self.stim.prepare(self.curr_cond)
         self.beh.prepare(self.curr_cond)
         super().entry()
+        self.stim.start_stim()
 
     def run(self):
         if not self.is_stopped() and self.beh.is_ready(self.curr_cond['init_ready'], self.start_time):

--- a/Experiments/MatchPort.py
+++ b/Experiments/MatchPort.py
@@ -103,7 +103,7 @@ class Trial(Experiment):
             self.stim.ready_stim()
 
     def next(self):
-        if not self.resp_ready and self.beh.interface.in_position()==(0,0,0):  # did not wait & 
+        if not self.resp_ready and self.beh.interface.in_position()==(0,0,0):  # did not wait
             return 'Abort'
         elif self.response and not self.beh.is_correct():  # response to incorrect probe
             return 'Punish'

--- a/Stimuli/Panda.py
+++ b/Stimuli/Panda.py
@@ -186,12 +186,13 @@ class Panda(Stimulus, dj.Manual):
             self.movie_node.setScale(48)
             self.movie_node.reparentTo(self.render)
 
+    def start(self):
+        if self.flag_no_stim: return
+
         if not self.isrunning:
             self.timer.start()
             self.isrunning = True
 
-    def start(self):
-        if self.flag_no_stim: return
         self.log_start()
         if self.movie: self.mov_texture.play()
         for idx, obj in enumerate(iterable(self.curr_cond['obj_id'])):
@@ -224,19 +225,19 @@ class Panda(Stimulus, dj.Manual):
         self.isrunning = False
 
     def punish_stim(self):
-        self.unshow((0, 0, 0))
+        self.unshow(self.monitor['punish_color'])
 
     def reward_stim(self):
-        self.unshow((0.5, 0.5, 0.5))
+        self.unshow(self.monitor['reward_color'])
     
     def ready_stim(self):
-        self.unshow((0.25, 0.25, 0.25))
+        self.unshow(self.monitor['ready_color'])
 
     def start_stim(self):
-        self.unshow((0.125, 0.125, 0.125))
+        self.unshow(self.monitor["start_color"])
 
     def unshow(self, color=None):
-        if not color: color = self.background_color
+        if not color: color = self.monitor['background_color']
         self.set_background_color(*color)
         self.flip(2)
 
@@ -304,6 +305,7 @@ class Agent(Panda):
         self.name = "Obj%s-Task" % cond['id']
 
     def run(self):
+        self.timer.start()
         self.model = self.env.loader.loadModel(self.env.object_files[self.cond['id']])
         self.model.reparentTo(self.env.render)
         self.task = self.env.taskMgr.doMethodLater(self.cond['delay']/1000, self.objTask, self.name)

--- a/Stimuli/Panda.py
+++ b/Stimuli/Panda.py
@@ -141,7 +141,7 @@ class Panda(Stimulus, dj.Manual):
         if stim_period == '':
             self.curr_cond = curr_cond
         elif stim_period not in curr_cond:
-            self.flag_no_stim True
+            self.flag_no_stim = True
             return
         else: 
             self.curr_cond = curr_cond[stim_period]
@@ -206,20 +206,20 @@ class Panda(Stimulus, dj.Manual):
             self.taskMgr.step()
 
     def stop(self):
-    if self.flag_no_stim: return
-    for idx, obj in self.objects.items():
-        obj.remove(obj.task)
-    for idx, light in self.lights.items():
-        self.render.clearLight(self.lightsNP[idx])
-    if self.movie:
-        self.mov_texture.stop()
-        self.movie_node.removeNode()
-        self.movie = False
-    self.render.clearLight
+        if self.flag_no_stim: return
+        for idx, obj in self.objects.items():
+            obj.remove(obj.task)
+        for idx, light in self.lights.items():
+            self.render.clearLight(self.lightsNP[idx])
+        if self.movie:
+            self.mov_texture.stop()
+            self.movie_node.removeNode()
+            self.movie = False
+        self.render.clearLight
 
-    self.flip(2) # clear double buffer
-    self.log_stop()
-    self.isrunning = False
+        self.flip(2) # clear double buffer
+        self.log_stop()
+        self.isrunning = False
 
     def punish_stim(self):
         self.unshow((0, 0, 0))

--- a/Stimuli/Panda.py
+++ b/Stimuli/Panda.py
@@ -1,5 +1,6 @@
 from core.Stimulus import *
 import os
+import time
 import numpy as np
 from direct.showbase.ShowBase import ShowBase
 from direct.showbase.Loader import Loader
@@ -135,6 +136,7 @@ class Panda(Stimulus, dj.Manual):
         self.ambientLight = core.AmbientLight('ambientLight')
         self.ambientLightNP = self.render.attachNewNode(self.ambientLight)
         self.render.setLight(self.ambientLightNP)
+        self.set_taskMgr()
 
     def prepare(self, curr_cond, stim_period=''):
         self.flag_no_stim = False
@@ -226,6 +228,12 @@ class Panda(Stimulus, dj.Manual):
 
     def reward_stim(self):
         self.unshow((0.5, 0.5, 0.5))
+    
+    def ready_stim(self):
+        self.unshow((0.25, 0.25, 0.25))
+
+    def start_stim(self):
+        self.unshow((0.125, 0.125, 0.125))
 
     def unshow(self, color=None):
         if not color: color = self.background_color
@@ -267,6 +275,15 @@ class Panda(Stimulus, dj.Manual):
     def get_clip_info(self, key, *fields):
         return self.logger.get(schema='stimulus', table='Movie.Clip', key=key, fields=fields)
 
+    def set_taskMgr(self):
+        """
+        Use this at the setup of pandas because for some reason the taskMgr the first time it 
+        doesn't work properly. It needs time sleep between steps or to run many steps
+        """
+        self.set_background_color((0,0,0))
+        for i in range(0, 2):
+            time.sleep(0.1)
+            self.taskMgr.step()
 
 class Agent(Panda):
     def __init__(self, env, cond):

--- a/Stimuli/RPScreen.py
+++ b/Stimuli/RPScreen.py
@@ -24,6 +24,9 @@ class RPScreen(Stimulus):
     def reward_stim(self):
         self.unshow([128, 128, 128])
 
+    def start_stim(self):
+        self.unshow([32,32,32])
+
     def stop(self):
         self.screen.fill([0, 0, 0])
         self.flip()

--- a/Stimuli/RPScreen.py
+++ b/Stimuli/RPScreen.py
@@ -6,7 +6,7 @@ from pygame.locals import *
 class RPScreen(Stimulus):
 
     def setup(self):
-        self.color = [32, 32, 32]  # default background color
+        self.color = [i*256 for i in self.monitor['background_color']]  # default background color
 
         # setup pygame
         if not pygame.get_init():
@@ -19,13 +19,16 @@ class RPScreen(Stimulus):
         self.flip()
         
     def ready_stim(self):
-        self.unshow([64, 64, 64])
+        self.unshow([i*256 for i in self.monitor['ready_color']])
 
     def reward_stim(self):
-        self.unshow([128, 128, 128])
+        self.unshow([i*256 for i in self.monitor['reward_color']])
+
+    def punish_stim(self):
+        self.unshow([i*256 for i in self.monitor['punish_color']])
 
     def start_stim(self):
-        self.unshow([32,32,32])
+        self.unshow([i*256 for i in self.monitor['start_color']])
 
     def stop(self):
         self.screen.fill([0, 0, 0])
@@ -35,8 +38,7 @@ class RPScreen(Stimulus):
 
     def unshow(self, color=False):
         """update background color"""
-        if not color:
-            color = self.color
+        if not color: color = self.color
         self.screen.fill(color)
         self.flip()
 

--- a/core/Experiment.py
+++ b/core/Experiment.py
@@ -433,6 +433,11 @@ class SetupConfiguration(dj.Lookup):
         resolution_x             : smallint
         resolution_y             : smallint
         discription              : varchar(256)
+        reward_color             : tinyblob
+        punish_color             : tinyblob
+        ready_color              : tinyblob
+        background_color         : tinyblob
+        start_color              : tinyblob
         """
 
     class Ball(dj.Part):


### PR DESCRIPTION
Changes in MatchPort and Pandas to be identical with RPScreen changes of screen color and add/use colors from setup_configuration__screen. Also if mouse get off center port before trial_ready go to abort.

Main changes:
1. Start stimulus at the begging of the session/trial : https://github.com/ef-lab/PyMouse/commit/980ab8da621658c55b613d31bd66702271ffaf6b
2. We want timer to start at the stim.start() and not at stim.prepare. Furthermore pandas object has its one timer which also needs to start when we run the object : https://github.com/ef-lab/PyMouse/commit/52a4ebf196dab05bb803cba58c0573fa9f84625e
3.   if mouse is off position go to abort: https://github.com/ef-lab/PyMouse/commit/6b256ff1a0fb0c369c42e4febd63df2b48a11158
4. before go to pretrial at InterTrial check that ports are off: https://github.com/ef-lab/PyMouse/commit/63b57e8f8513415c1f2467f729dfa24bf47a0bab

