### PR TITLE
Queue get response

### DIFF
--- a/core/Behavior.py
+++ b/core/Behavior.py
@@ -7,7 +7,7 @@ import bisect
 from importlib import import_module
 from dataclasses import dataclass, fields
 from dataclasses import field as datafield
-
+from queue import Queue
 
 @behavior.schema
 class Rewards(dj.Manual):


### PR DESCRIPTION
Because log_activity is running in the callbacks of interface (multi threading) the get_response can be interrupted from log_activity and after read the last_response overwrite it at the if statement in clean.

So we are using a Queue to save the activity instead in order to be thread safe.

The size of the Queue is small (max_size=3) since the the get_response is called more often than log and we want to create to create a big array and slow down the get_response because it must running fast