### PR TITLE
Fix on trials_selection =  staircase

### DIFF
--- a/core/Experiment.py
+++ b/core/Experiment.py
@@ -56,7 +56,7 @@ class ExperimentClass:
 
     def setup(self, logger, BehaviorClass, session_params):
         self.running = False
-        self.conditions, self.quit, self.curr_cond, self.dif_h, self.stims, self.curr_trial = [], False, dict(), [], dict(),0
+        self.conditions, self.iter, self.quit, self.curr_cond, self.dif_h, self.stims, self.curr_trial = [], [], False, dict(), [], dict(),0
         if "setup_conf_idx" not in self.default_key: self.default_key["setup_conf_idx"] = 0
         self.params = {**self.default_key, **session_params}
         self.logger = logger
@@ -216,11 +216,12 @@ class ExperimentClass:
             choice_h = np.int64(np.asarray(self.beh.choice_history)[idx])
             choice_h = [[c, d] for c, d in zip(choice_h, np.asarray(self.dif_h)[idx])]
             if self.iter == 1 or np.size(self.iter) == 0:
-                self.iter = self.params['staircase_window']
-                perf = np.nanmean(np.greater(rew_h[-self.params['staircase_window']:], 0))
-                if   perf >= self.params['stair_up']   and self.cur_dif < max(self.difs):  self.cur_dif += 1
-                elif perf < self.params['stair_down'] and self.cur_dif > 1:  self.cur_dif -= 1
-                self.logger.update_setup_info({'difficulty': self.cur_dif})
+                if (self.beh.choice_history[-1:][0]>0 if np.size(self.beh.choice_history)!=0 else True):
+                    self.iter = self.params['staircase_window']
+                    perf = np.nanmean(np.greater(rew_h[-self.params['staircase_window']:], 0))
+                    if   perf >= self.params['stair_up']   and self.cur_dif < max(self.difs):  self.cur_dif += 1
+                    elif perf < self.params['stair_down'] and self.cur_dif > 1:  self.cur_dif -= 1
+                    self.logger.update_setup_info({'difficulty': self.cur_dif})
             elif np.size(self.beh.choice_history) and self.beh.choice_history[-1:][0] > 0: self.iter -= 1
             anti_bias = self._anti_bias(choice_h, self.un_choices[self.un_difs == self.cur_dif])
             sel_conds = [i for (i, v) in zip(self.conditions, np.logical_and(self.choices == anti_bias,


### PR DESCRIPTION
iter is initialized at the decleration of ExperimentClass line 33 core/Experiment.py so when a new session begins after sleeping it keeps the last value of iter. So instead I initialize self.iter at the setup function of ExperimentClass.

At line 218 core/Experiment.py when self.iter=1 it doesn't check it the last trial is abort before decide if it must move on the next difficulty or not. At line 219 core/Experiment.py I check if there are some choices and the last one is not abort only then check the performace.